### PR TITLE
C++11 compiler related warning fixes

### DIFF
--- a/DicomCli/progress.h
+++ b/DicomCli/progress.h
@@ -23,7 +23,7 @@ public:
   static ProgressObserver *New() { return new ProgressObserver; }
   vtkTypeMacro(ProgressObserver,vtkCommand);
   virtual void Execute(
-    vtkObject *caller, unsigned long eventId, void *callData);
+    vtkObject *caller, unsigned long eventId, void *callData) VTK_OVERRIDE;
   void SetText(const char *text) { this->Text = text; }
 protected:
   ProgressObserver() : Stage(0), Anim(0), LastTime(0), Text("") {}

--- a/DicomCli/vtkConsoleOutputWindow.h
+++ b/DicomCli/vtkConsoleOutputWindow.h
@@ -28,8 +28,8 @@ class vtkConsoleOutputWindow : public vtkOutputWindow
 public:
   vtkTypeMacro(vtkConsoleOutputWindow, vtkOutputWindow);
   static vtkConsoleOutputWindow* New();
-  virtual void PrintSelf(ostream& os, vtkIndent indent);
-  virtual void DisplayText(const char*);
+  virtual void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+  virtual void DisplayText(const char*) VTK_OVERRIDE;
   static void Install();
 
 protected:
@@ -38,8 +38,8 @@ protected:
   void Initialize();
 
 private:
-  vtkConsoleOutputWindow(const vtkConsoleOutputWindow&);  // Not implemented.
-  void operator=(const vtkConsoleOutputWindow&);  // Not implemented.
+  vtkConsoleOutputWindow(const vtkConsoleOutputWindow&) VTK_DELETE_FUNCTION;
+  void operator=(const vtkConsoleOutputWindow&) VTK_DELETE_FUNCTION;
 };
 
 #endif

--- a/Source/vtkDICOMAlgorithm.h
+++ b/Source/vtkDICOMAlgorithm.h
@@ -43,7 +43,7 @@ public:
   static vtkDICOMAlgorithm *New();
 
   //! Print information about this object.
-  virtual void PrintSelf(ostream& os, vtkIndent indent);
+  virtual void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
   //@}
 
   //@{
@@ -82,20 +82,20 @@ protected:
 
   virtual int RequestInformation(
     vtkInformation* request, vtkInformationVector** inputVector,
-    vtkInformationVector* outputVector);
+    vtkInformationVector* outputVector) VTK_OVERRIDE;
 
   virtual int RequestData(
     vtkInformation* request, vtkInformationVector** inputVector,
-    vtkInformationVector* outputVector);
+    vtkInformationVector* outputVector) VTK_OVERRIDE;
 
   virtual void ThreadedRequestData(
     vtkInformation *request, vtkInformationVector **inputVector,
     vtkInformationVector *outputVector, vtkImageData ***inData,
-    vtkImageData **outData, int ext[6], int id);
+    vtkImageData **outData, int ext[6], int id) VTK_OVERRIDE;
 
 private:
-  vtkDICOMAlgorithm(const vtkDICOMAlgorithm&);  // Not implemented.
-  void operator=(const vtkDICOMAlgorithm&);  // Not implemented.
+  vtkDICOMAlgorithm(const vtkDICOMAlgorithm&) VTK_DELETE_FUNCTION;
+  void operator=(const vtkDICOMAlgorithm&) VTK_DELETE_FUNCTION;
 };
 
 #endif // vtkDICOMAlgorithm_h

--- a/Source/vtkDICOMCTGenerator.h
+++ b/Source/vtkDICOMCTGenerator.h
@@ -33,7 +33,7 @@ public:
   vtkTypeMacro(vtkDICOMCTGenerator, vtkDICOMGenerator);
 
   //! Print information about this object.
-  virtual void PrintSelf(ostream& os, vtkIndent indent);
+  virtual void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
   //! Generate an instance of one of the supported classes.
   /*!
@@ -41,7 +41,7 @@ public:
    *  information for a vtkImageData object, it will populate the
    *  attributes of the supplied vtkDICOMMetaData object.
    */
-  virtual bool GenerateInstance(vtkInformation *info);
+  virtual bool GenerateInstance(vtkInformation *info) VTK_OVERRIDE;
 
 protected:
   vtkDICOMCTGenerator();
@@ -57,8 +57,8 @@ protected:
   virtual bool GenerateCTInstance(vtkInformation *info);
 
 private:
-  vtkDICOMCTGenerator(const vtkDICOMCTGenerator&);  // Not implemented.
-  void operator=(const vtkDICOMCTGenerator&);  // Not implemented.
+  vtkDICOMCTGenerator(const vtkDICOMCTGenerator&) VTK_DELETE_FUNCTION;
+  void operator=(const vtkDICOMCTGenerator&) VTK_DELETE_FUNCTION;
 };
 
 #endif // vtkDICOMCTGenerator_h

--- a/Source/vtkDICOMCTRectifier.h
+++ b/Source/vtkDICOMCTRectifier.h
@@ -36,7 +36,7 @@ public:
   vtkTypeMacro(vtkDICOMCTRectifier, vtkDICOMAlgorithm);
 
   //! Print information about this object.
-  virtual void PrintSelf(ostream& os, vtkIndent indent);
+  virtual void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
   //@{
   //! Reverse the default operation.
@@ -103,20 +103,20 @@ protected:
 
   virtual int RequestInformation(
     vtkInformation* request, vtkInformationVector** inputVector,
-    vtkInformationVector* outputVector);
+    vtkInformationVector* outputVector) VTK_OVERRIDE;
 
   virtual int RequestUpdateExtent(
     vtkInformation* request, vtkInformationVector** inputVector,
-    vtkInformationVector* outputVector);
+    vtkInformationVector* outputVector) VTK_OVERRIDE;
 
   virtual int RequestData(
     vtkInformation* request, vtkInformationVector** inputVector,
-    vtkInformationVector* outputVector);
+    vtkInformationVector* outputVector) VTK_OVERRIDE;
 
   virtual void ThreadedRequestData(
     vtkInformation *request, vtkInformationVector **inputVector,
     vtkInformationVector *outputVector, vtkImageData ***inData,
-    vtkImageData **outData, int ext[6], int id);
+    vtkImageData **outData, int ext[6], int id) VTK_OVERRIDE;
 
   vtkMatrix4x4 *VolumeMatrix;
   vtkMatrix4x4 *RectifiedMatrix;
@@ -124,8 +124,8 @@ protected:
   int Reverse;
 
 private:
-  vtkDICOMCTRectifier(const vtkDICOMCTRectifier&);  // Not implemented.
-  void operator=(const vtkDICOMCTRectifier&);  // Not implemented.
+  vtkDICOMCTRectifier(const vtkDICOMCTRectifier&) VTK_DELETE_FUNCTION;
+  void operator=(const vtkDICOMCTRectifier&) VTK_DELETE_FUNCTION;
 };
 
 #endif // vtkDICOMCTRectifier_h

--- a/Source/vtkDICOMDirectory.h
+++ b/Source/vtkDICOMDirectory.h
@@ -33,7 +33,7 @@ class VTKDICOM_EXPORT vtkDICOMDirectory : public vtkAlgorithm
 {
 public:
   vtkTypeMacro(vtkDICOMDirectory,vtkAlgorithm);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
   static vtkDICOMDirectory *New();
 
   //! Levels within the DICOM information model.
@@ -118,11 +118,12 @@ public:
    * This method causes the directory to be read.  It must be called before
    * any of the Get methods.
    */
-  virtual void Update() { this->Update(0); }
-  virtual void Update(int);
+  virtual void Update() VTK_OVERRIDE { this->Update(0); }
+  virtual void Update(int) VTK_OVERRIDE;
 #if (VTK_MAJOR_VERSION == 7 && VTK_MINOR_VERSION > 0) || VTK_MAJOR_VERSION > 7
-  virtual int Update(vtkInformation *) { this->Update(); return 1; }
-  virtual int Update(int i, vtkInformationVector *) {
+  virtual int Update(vtkInformation *) VTK_OVERRIDE {
+    this->Update(); return 1; }
+  virtual int Update(int i, vtkInformationVector *) VTK_OVERRIDE {
     this->Update(i); return 1; }
 #endif
   //@}
@@ -299,7 +300,7 @@ protected:
   void SetInternalFileName(const char *fname);
 
   //! Set the error code.
-  void SetErrorCode(unsigned long e) { this->ErrorCode = e; }
+  void SetErrorCode(unsigned long e) VTK_OVERRIDE { this->ErrorCode = e; }
 
   //! Add all of the series listed in a DICOMDIR file.
   /*!
@@ -321,8 +322,8 @@ protected:
     vtkDICOMMetaData *meta, const vtkDICOMItem *item, int instance);
 
 private:
-  vtkDICOMDirectory(const vtkDICOMDirectory&);  // Not implemented.
-  void operator=(const vtkDICOMDirectory&);  // Not implemented.
+  vtkDICOMDirectory(const vtkDICOMDirectory&) VTK_DELETE_FUNCTION;
+  void operator=(const vtkDICOMDirectory&) VTK_DELETE_FUNCTION;
 
   struct SeriesItem;
   struct StudyItem;

--- a/Source/vtkDICOMFileSorter.h
+++ b/Source/vtkDICOMFileSorter.h
@@ -33,7 +33,7 @@ class VTKDICOM_EXPORT vtkDICOMFileSorter : public vtkObject
 {
 public:
   vtkTypeMacro(vtkDICOMFileSorter,vtkObject);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
   static vtkDICOMFileSorter *New();
 
   //@{
@@ -147,8 +147,8 @@ protected:
   void SetErrorCode(unsigned long e) { this->ErrorCode = e; }
 
 private:
-  vtkDICOMFileSorter(const vtkDICOMFileSorter&);  // Not implemented.
-  void operator=(const vtkDICOMFileSorter&);  // Not implemented.
+  vtkDICOMFileSorter(const vtkDICOMFileSorter&) VTK_DELETE_FUNCTION;
+  void operator=(const vtkDICOMFileSorter&) VTK_DELETE_FUNCTION;
 
   class StringArrayVector;
   struct FileInfo;

--- a/Source/vtkDICOMGenerator.h
+++ b/Source/vtkDICOMGenerator.h
@@ -48,7 +48,7 @@ public:
   vtkTypeMacro(vtkDICOMGenerator, vtkObject);
 
   //! Print information about this object.
-  virtual void PrintSelf(ostream& os, vtkIndent indent);
+  virtual void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
   //@{
   //! Generate an instance of one of the supported classes.
@@ -466,8 +466,8 @@ protected:
   vtkIntArray *RangeArray;
 
 private:
-  vtkDICOMGenerator(const vtkDICOMGenerator&);  // Not implemented.
-  void operator=(const vtkDICOMGenerator&);  // Not implemented.
+  vtkDICOMGenerator(const vtkDICOMGenerator&) VTK_DELETE_FUNCTION;
+  void operator=(const vtkDICOMGenerator&) VTK_DELETE_FUNCTION;
 };
 
 #endif // vtkDICOMGenerator_h

--- a/Source/vtkDICOMMRGenerator.h
+++ b/Source/vtkDICOMMRGenerator.h
@@ -33,7 +33,7 @@ public:
   vtkTypeMacro(vtkDICOMMRGenerator, vtkDICOMGenerator);
 
   //! Print information about this object.
-  virtual void PrintSelf(ostream& os, vtkIndent indent);
+  virtual void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
   //! Generate an instance of one of the supported classes.
   /*!
@@ -41,7 +41,7 @@ public:
    *  information for a vtkImageData object, it will populate the
    *  attributes of the supplied vtkDICOMMetaData object.
    */
-  virtual bool GenerateInstance(vtkInformation *info);
+  virtual bool GenerateInstance(vtkInformation *info) VTK_OVERRIDE;
 
 protected:
   vtkDICOMMRGenerator();
@@ -57,8 +57,8 @@ protected:
   virtual bool GenerateMRInstance(vtkInformation *info);
 
 private:
-  vtkDICOMMRGenerator(const vtkDICOMMRGenerator&);  // Not implemented.
-  void operator=(const vtkDICOMMRGenerator&);  // Not implemented.
+  vtkDICOMMRGenerator(const vtkDICOMMRGenerator&) VTK_DELETE_FUNCTION;
+  void operator=(const vtkDICOMMRGenerator&) VTK_DELETE_FUNCTION;
 };
 
 #endif // vtkDICOMMRGenerator_h

--- a/Source/vtkDICOMMetaData.h
+++ b/Source/vtkDICOMMetaData.h
@@ -39,7 +39,7 @@ public:
   vtkTypeMacro(vtkDICOMMetaData, vtkDataObject);
 
   //! Print a summary of the contents of this object.
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
   //@{
   //! Get the number of instances (i.e. files).
@@ -59,7 +59,7 @@ public:
   void Clear();
 
   //! Remove all data elements and initialize all members.
-  void Initialize();
+  void Initialize() VTK_OVERRIDE;
   //@}
 
   //@{
@@ -280,8 +280,8 @@ public:
 
   //@{
   //! DataObject interface function.
-  void ShallowCopy(vtkDataObject *source);
-  void DeepCopy(vtkDataObject *source);
+  void ShallowCopy(vtkDataObject *source) VTK_OVERRIDE;
+  void DeepCopy(vtkDataObject *source) VTK_OVERRIDE;
   //@}
 
 protected:
@@ -331,8 +331,8 @@ private:
   //! An array to map slices and components to frames.
   vtkIntArray *FrameIndexArray;
 
-  vtkDICOMMetaData(const vtkDICOMMetaData&);  // Not implemented.
-  void operator=(const vtkDICOMMetaData&);  // Not implemented.
+  vtkDICOMMetaData(const vtkDICOMMetaData&) VTK_DELETE_FUNCTION;
+  void operator=(const vtkDICOMMetaData&) VTK_DELETE_FUNCTION;
 };
 
 #endif /* vtkDICOMMetaData_h */

--- a/Source/vtkDICOMParser.h
+++ b/Source/vtkDICOMParser.h
@@ -42,7 +42,7 @@ public:
   vtkTypeMacro(vtkDICOMParser, vtkObject);
 
   //! Print a summary of the contents of this object.
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
   //@{
   //! Set the file name.
@@ -202,8 +202,8 @@ protected:
   friend class vtkDICOMParserInternalFriendship;
 
 private:
-  vtkDICOMParser(const vtkDICOMParser&);  // Not implemented.
-  void operator=(const vtkDICOMParser&);  // Not implemented.
+  vtkDICOMParser(const vtkDICOMParser&) VTK_DELETE_FUNCTION;
+  void operator=(const vtkDICOMParser&) VTK_DELETE_FUNCTION;
 };
 
 #endif /* vtkDICOMParser_h */

--- a/Source/vtkDICOMReader.h
+++ b/Source/vtkDICOMReader.h
@@ -43,19 +43,19 @@ public:
   static vtkDICOMReader *New();
 
   //! Print information about this object.
-  virtual void PrintSelf(ostream& os, vtkIndent indent);
+  virtual void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
   //@{
   //! Valid extensions for this file type.
-  virtual const char* GetFileExtensions() {
+  virtual const char* GetFileExtensions() VTK_OVERRIDE {
     return ".dcm .dc"; }
 
   //! Return a descriptive name that might be useful in a GUI.
-  virtual const char* GetDescriptiveName() {
+  virtual const char* GetDescriptiveName() VTK_OVERRIDE {
     return "DICOM"; }
 
   //! Return true if this reader can read the given file.
-  int CanReadFile(const char* filename);
+  int CanReadFile(const char* filename) VTK_OVERRIDE;
   //@}
 
   //@{
@@ -237,12 +237,12 @@ protected:
   //! Read the header information.
   virtual int RequestInformation(
     vtkInformation* request, vtkInformationVector** inputVector,
-    vtkInformationVector* outputVector);
+    vtkInformationVector* outputVector) VTK_OVERRIDE;
 
   //! Read the voxel data.
   virtual int RequestData(
     vtkInformation* request, vtkInformationVector** inputVector,
-    vtkInformationVector* outputVector);
+    vtkInformationVector* outputVector) VTK_OVERRIDE;
   //@}
 
   //@{
@@ -366,8 +366,8 @@ protected:
   char DesiredStackID[20];
 
 private:
-  vtkDICOMReader(const vtkDICOMReader&);  // Not implemented.
-  void operator=(const vtkDICOMReader&);  // Not implemented.
+  vtkDICOMReader(const vtkDICOMReader&) VTK_DELETE_FUNCTION;
+  void operator=(const vtkDICOMReader&) VTK_DELETE_FUNCTION;
 };
 
 #endif // vtkDICOMReader_h

--- a/Source/vtkDICOMToRAS.h
+++ b/Source/vtkDICOMToRAS.h
@@ -40,7 +40,7 @@ public:
   vtkTypeMacro(vtkDICOMToRAS, vtkThreadedImageAlgorithm);
 
   //! Print information about this object.
-  virtual void PrintSelf(ostream& os, vtkIndent indent);
+  virtual void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
   //@{
   //! Perform RAS to DICOM instead of DICOM to RAS.
@@ -140,20 +140,20 @@ protected:
 
   virtual int RequestInformation(
     vtkInformation* request, vtkInformationVector** inputVector,
-    vtkInformationVector* outputVector);
+    vtkInformationVector* outputVector) VTK_OVERRIDE;
 
   virtual int RequestUpdateExtent(
     vtkInformation* request, vtkInformationVector** inputVector,
-    vtkInformationVector* outputVector);
+    vtkInformationVector* outputVector) VTK_OVERRIDE;
 
   virtual int RequestData(
     vtkInformation* request, vtkInformationVector** inputVector,
-    vtkInformationVector* outputVector);
+    vtkInformationVector* outputVector) VTK_OVERRIDE;
 
   virtual void ThreadedRequestData(
     vtkInformation *request, vtkInformationVector **inputVector,
     vtkInformationVector *outputVector, vtkImageData ***inData,
-    vtkImageData **outData, int ext[6], int id);
+    vtkImageData **outData, int ext[6], int id) VTK_OVERRIDE;
 
   vtkMatrix4x4 *PatientMatrix;
   vtkMatrix4x4 *RASMatrix;
@@ -167,8 +167,8 @@ protected:
   double Matrix[16];
 
 private:
-  vtkDICOMToRAS(const vtkDICOMToRAS&);  // Not implemented.
-  void operator=(const vtkDICOMToRAS&);  // Not implemented.
+  vtkDICOMToRAS(const vtkDICOMToRAS&) VTK_DELETE_FUNCTION;
+  void operator=(const vtkDICOMToRAS&) VTK_DELETE_FUNCTION;
 };
 
 #endif // vtkDICOMToRAS_h

--- a/Source/vtkDICOMUtilities.h
+++ b/Source/vtkDICOMUtilities.h
@@ -33,7 +33,7 @@ public:
   vtkTypeMacro(vtkDICOMUtilities, vtkObject);
 
   //! Print a summary of the contents of this object.
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
   //@}
 
   //@{
@@ -192,8 +192,8 @@ protected:
   static char ImplementationVersionName[17];
 
 private:
-  vtkDICOMUtilities(const vtkDICOMUtilities&);  // Not implemented.
-  void operator=(const vtkDICOMUtilities&);  // Not implemented.
+  vtkDICOMUtilities(const vtkDICOMUtilities&) VTK_DELETE_FUNCTION;
+  void operator=(const vtkDICOMUtilities&) VTK_DELETE_FUNCTION;
 };
 
 #endif /* vtkDICOMUtilities_h */

--- a/Source/vtkDICOMWriter.h
+++ b/Source/vtkDICOMWriter.h
@@ -41,7 +41,7 @@ public:
   static vtkDICOMWriter *New();
 
   //! Print information about this object.
-  virtual void PrintSelf(ostream& os, vtkIndent indent);
+  virtual void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
   //@{
   //! Set a short description (max 64 chars) for the DICOM series.
@@ -208,7 +208,7 @@ public:
 
   //@{
   //! Write the file to disk.
-  virtual void Write();
+  virtual void Write() VTK_OVERRIDE;
   //@}
 
 protected:
@@ -227,7 +227,7 @@ protected:
   //! The main execution method, which writes the file.
   virtual int RequestData(vtkInformation *request,
                           vtkInformationVector** inputVector,
-                          vtkInformationVector* outputVector);
+                          vtkInformationVector* outputVector) VTK_OVERRIDE;
 
   //! The meta data set by the user.
   vtkDICOMMetaData *MetaData;
@@ -271,8 +271,8 @@ protected:
   int Streaming;
 
 private:
-  vtkDICOMWriter(const vtkDICOMWriter&);  // Not implemented.
-  void operator=(const vtkDICOMWriter&);  // Not implemented.
+  vtkDICOMWriter(const vtkDICOMWriter&) VTK_DELETE_FUNCTION;
+  void operator=(const vtkDICOMWriter&) VTK_DELETE_FUNCTION;
 };
 
 #endif // vtkDICOMWriter_h

--- a/Source/vtkNIFTIHeader.h
+++ b/Source/vtkNIFTIHeader.h
@@ -162,7 +162,7 @@ public:
   vtkTypeMacro(vtkNIFTIHeader, vtkObject);
 
   //! Print information about this object.
-  virtual void PrintSelf(ostream& os, vtkIndent indent);
+  virtual void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
   //@{
   //! Get the magic number for the NIFTI file as a null-terminated string.
@@ -408,8 +408,8 @@ protected:
   void SetStringValue(char *x, const char *y, size_t n);
 
 private:
-  vtkNIFTIHeader(const vtkNIFTIHeader&);  // Not implemented.
-  void operator=(const vtkNIFTIHeader&);  // Not implemented.
+  vtkNIFTIHeader(const vtkNIFTIHeader&) VTK_DELETE_FUNCTION;
+  void operator=(const vtkNIFTIHeader&) VTK_DELETE_FUNCTION;
 };
 
 #endif // vtkNIFTIHeader_h

--- a/Source/vtkNIFTIReader.h
+++ b/Source/vtkNIFTIReader.h
@@ -51,19 +51,19 @@ public:
   vtkTypeMacro(vtkNIFTIReader, vtkImageReader2);
 
   //! Print information about this object.
-  virtual void PrintSelf(ostream& os, vtkIndent indent);
+  virtual void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
   //@{
   //! Valid extensions for this file type.
-  virtual const char* GetFileExtensions() {
+  virtual const char* GetFileExtensions() VTK_OVERRIDE {
     return ".nii .nii.gz .img .img.gz .hdr .hdr.gz"; }
 
   //! Return a descriptive name that might be useful in a GUI.
-  virtual const char* GetDescriptiveName() {
+  virtual const char* GetDescriptiveName() VTK_OVERRIDE {
     return "NIfTI"; }
 
   //! Return true if this reader can read the given file.
-  int CanReadFile(const char* filename);
+  int CanReadFile(const char* filename) VTK_OVERRIDE;
   //@}
 
   //@{
@@ -168,12 +168,12 @@ protected:
   //! Read the header information.
   virtual int RequestInformation(
     vtkInformation* request, vtkInformationVector** inputVector,
-    vtkInformationVector* outputVector);
+    vtkInformationVector* outputVector) VTK_OVERRIDE;
 
   //! Read the voxel data.
   virtual int RequestData(
     vtkInformation* request, vtkInformationVector** inputVector,
-    vtkInformationVector* outputVector);
+    vtkInformationVector* outputVector) VTK_OVERRIDE;
 
   //! Doe a case-insensitive check for the given extension.
   /*!

--- a/Source/vtkNIFTIWriter.h
+++ b/Source/vtkNIFTIWriter.h
@@ -53,7 +53,7 @@ public:
   vtkTypeMacro(vtkNIFTIWriter, vtkImageWriter);
 
   //! Print information about this object.
-  virtual void PrintSelf(ostream& os, vtkIndent indent);
+  virtual void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
   //@{
   //! Set the version number for the NIfTI file format to use.
@@ -187,7 +187,7 @@ protected:
   //! The main execution method, which writes the file.
   virtual int RequestData(vtkInformation *request,
                           vtkInformationVector** inputVector,
-                          vtkInformationVector* outputVector);
+                          vtkInformationVector* outputVector) VTK_OVERRIDE;
 
   //! Make a new filename by replacing extension "ext1" with "ext2".
   /*!
@@ -228,8 +228,8 @@ protected:
   EndianEnum DataByteOrder;
 
 private:
-  vtkNIFTIWriter(const vtkNIFTIWriter&);  // Not implemented.
-  void operator=(const vtkNIFTIWriter&);  // Not implemented.
+  vtkNIFTIWriter(const vtkNIFTIWriter&) VTK_DELETE_FUNCTION;
+  void operator=(const vtkNIFTIWriter&) VTK_DELETE_FUNCTION;
 };
 
 #endif // vtkNIFTIWriter_h

--- a/Source/vtkScancoCTReader.h
+++ b/Source/vtkScancoCTReader.h
@@ -45,21 +45,21 @@ public:
   vtkTypeMacro(vtkScancoCTReader, vtkImageReader2);
 
   //! Print information about this object.
-  virtual void PrintSelf(ostream& os, vtkIndent indent);
+  virtual void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
   //@{
   //! Valid extensions for this file type.
-  virtual const char* GetFileExtensions() {
+  virtual const char* GetFileExtensions() VTK_OVERRIDE {
     return ".isq .rsq .rad .aim" ; }
 
   //! Return a descriptive name that might be useful in a GUI.
-  virtual const char* GetDescriptiveName() {
+  virtual const char* GetDescriptiveName() VTK_OVERRIDE {
     return "SCANCO MicroCT"; }
   //@}
 
   //@{
   //! Return true if this reader can read the given file.
-  int CanReadFile(const char* filename);
+  int CanReadFile(const char* filename) VTK_OVERRIDE;
   //@}
 
   //@{
@@ -172,12 +172,12 @@ protected:
   //! Read the header information.
   virtual int RequestInformation(
     vtkInformation* request, vtkInformationVector** inputVector,
-    vtkInformationVector* outputVector);
+    vtkInformationVector* outputVector) VTK_OVERRIDE;
 
   //! Read the voxel data.
   virtual int RequestData(
     vtkInformation* request, vtkInformationVector** inputVector,
-    vtkInformationVector* outputVector);
+    vtkInformationVector* outputVector) VTK_OVERRIDE;
 
   //! Initialize the header information
   void InitializeHeader();
@@ -254,8 +254,8 @@ protected:
   int Compression;
 
 private:
-  vtkScancoCTReader(const vtkScancoCTReader&);  // Not implemented.
-  void operator=(const vtkScancoCTReader&);  // Not implemented.
+  vtkScancoCTReader(const vtkScancoCTReader&) VTK_DELETE_FUNCTION;
+  void operator=(const vtkScancoCTReader&) VTK_DELETE_FUNCTION;
 };
 
 #endif // vtkScancoCTReader_h


### PR DESCRIPTION
Added VTK_OVERRIDE and VTK_DELETE_FUNCTION macros