### PR TITLE
vtkNIFTI: check for Windows properly

### DIFF
--- a/Source/vtkNIFTIReader.cxx
+++ b/Source/vtkNIFTIReader.cxx
@@ -317,7 +317,7 @@ int vtkNIFTIReader::CanReadFile(const char *filename)
     return 0;
   }
 
-#if _WIN32
+#ifdef _WIN32
   vtkDICOMFilePath fp(hdrname);
 #if VTK_MAJOR_VERSION < 7
   // convert to the local character set
@@ -439,7 +439,7 @@ int vtkNIFTIReader::RequestInformation(
 
   vtkDebugMacro("Opening NIFTI file " << hdrname);
 
-#if _WIN32
+#ifdef _WIN32
   vtkDICOMFilePath fph(hdrname);
 #if VTK_MAJOR_VERSION < 7
   // convert to the local character set
@@ -1105,7 +1105,7 @@ int vtkNIFTIReader::RequestData(
   unsigned char *dataPtr =
     static_cast<unsigned char *>(data->GetScalarPointer());
 
-#if _WIN32
+#ifdef _WIN32
   vtkDICOMFilePath fpi(imgname);
 #if VTK_MAJOR_VERSION < 7
   // convert to the local character set

--- a/Source/vtkNIFTIWriter.cxx
+++ b/Source/vtkNIFTIWriter.cxx
@@ -720,7 +720,7 @@ int vtkNIFTIWriter::RequestData(
     }
   }
 
-#if _WIN32
+#ifdef _WIN32
   vtkDICOMFilePath fph(hdrname);
   vtkDICOMFilePath fpi(imgname);
 #if VTK_MAJOR_VERSION < 7


### PR DESCRIPTION
Fixes builds with `-Werror=undef`.