### PR TITLE
Add VTK_DICOM_OVERRIDE to overridden destructors

### DIFF
--- a/DicomCli/vtkConsoleOutputWindow.h
+++ b/DicomCli/vtkConsoleOutputWindow.h
@@ -35,7 +35,7 @@ public:
 
 protected:
   vtkConsoleOutputWindow();
-  virtual ~vtkConsoleOutputWindow();
+  virtual ~vtkConsoleOutputWindow() VTK_DICOM_OVERRIDE;
   void Initialize();
 
 private:

--- a/Source/vtkDICOMAlgorithm.h
+++ b/Source/vtkDICOMAlgorithm.h
@@ -58,7 +58,7 @@ public:
 
 protected:
   vtkDICOMAlgorithm();
-  ~vtkDICOMAlgorithm();
+  ~vtkDICOMAlgorithm() VTK_DICOM_OVERRIDE;
 
   //@{
   //! Get the information object that holds the meta data for the given input.

--- a/Source/vtkDICOMApplyPalette.h
+++ b/Source/vtkDICOMApplyPalette.h
@@ -47,7 +47,7 @@ public:
 
 protected:
   vtkDICOMApplyPalette();
-  ~vtkDICOMApplyPalette();
+  ~vtkDICOMApplyPalette() VTK_DICOM_OVERRIDE;
 
   int RequestInformation(
     vtkInformation* request, vtkInformationVector** inputVector,

--- a/Source/vtkDICOMApplyRescale.h
+++ b/Source/vtkDICOMApplyRescale.h
@@ -58,7 +58,7 @@ public:
 
 protected:
   vtkDICOMApplyRescale();
-  ~vtkDICOMApplyRescale();
+  ~vtkDICOMApplyRescale() VTK_DICOM_OVERRIDE;
 
   int RequestInformation(
     vtkInformation* request, vtkInformationVector** inputVector,

--- a/Source/vtkDICOMCTGenerator.h
+++ b/Source/vtkDICOMCTGenerator.h
@@ -45,7 +45,7 @@ public:
 
 protected:
   vtkDICOMCTGenerator();
-  ~vtkDICOMCTGenerator();
+  ~vtkDICOMCTGenerator() VTK_DICOM_OVERRIDE;
 
   //! Generate the Series Module.
   virtual bool GenerateCTSeriesModule(vtkDICOMMetaData *source);

--- a/Source/vtkDICOMCTRectifier.h
+++ b/Source/vtkDICOMCTRectifier.h
@@ -121,7 +121,7 @@ public:
 
 protected:
   vtkDICOMCTRectifier();
-  ~vtkDICOMCTRectifier();
+  ~vtkDICOMCTRectifier() VTK_DICOM_OVERRIDE;
 
   //! Compute the rectified matrix from the given volume matrix.
   /*!

--- a/Source/vtkDICOMCompiler.h
+++ b/Source/vtkDICOMCompiler.h
@@ -194,7 +194,7 @@ public:
 
 protected:
   vtkDICOMCompiler();
-  ~vtkDICOMCompiler();
+  ~vtkDICOMCompiler() VTK_DICOM_OVERRIDE;
 
   //! Internal method for flushing the IO buffer.
   /*!

--- a/Source/vtkDICOMDirectory.h
+++ b/Source/vtkDICOMDirectory.h
@@ -278,7 +278,7 @@ public:
 
 protected:
   vtkDICOMDirectory();
-  ~vtkDICOMDirectory();
+  ~vtkDICOMDirectory() VTK_DICOM_OVERRIDE;
 
   const char *DirectoryName;
   vtkStringArray *InputFileNames;

--- a/Source/vtkDICOMFileSorter.h
+++ b/Source/vtkDICOMFileSorter.h
@@ -110,7 +110,7 @@ public:
 
 protected:
   vtkDICOMFileSorter();
-  ~vtkDICOMFileSorter();
+  ~vtkDICOMFileSorter() VTK_DICOM_OVERRIDE;
 
   const char *InputFileName;
   vtkStringArray *InputFileNames;

--- a/Source/vtkDICOMGenerator.h
+++ b/Source/vtkDICOMGenerator.h
@@ -242,7 +242,7 @@ protected:
   //@{
   //! Protected constructor method.
   vtkDICOMGenerator();
-  ~vtkDICOMGenerator();
+  ~vtkDICOMGenerator() VTK_DICOM_OVERRIDE;
   //@}
 
   //@{

--- a/Source/vtkDICOMLookupTable.h
+++ b/Source/vtkDICOMLookupTable.h
@@ -58,7 +58,7 @@ public:
 
 protected:
   vtkDICOMLookupTable();
-  ~vtkDICOMLookupTable();
+  ~vtkDICOMLookupTable() VTK_DICOM_OVERRIDE;
 
   //! Build a lookup table from compressed data.
   /*!

--- a/Source/vtkDICOMMRGenerator.h
+++ b/Source/vtkDICOMMRGenerator.h
@@ -45,7 +45,7 @@ public:
 
 protected:
   vtkDICOMMRGenerator();
-  ~vtkDICOMMRGenerator();
+  ~vtkDICOMMRGenerator() VTK_DICOM_OVERRIDE;
 
   //! Generate the Series Module.
   virtual bool GenerateMRSeriesModule(vtkDICOMMetaData *source);

--- a/Source/vtkDICOMMetaData.h
+++ b/Source/vtkDICOMMetaData.h
@@ -330,7 +330,7 @@ public:
 
 protected:
   vtkDICOMMetaData();
-  ~vtkDICOMMetaData();
+  ~vtkDICOMMetaData() VTK_DICOM_OVERRIDE;
 
   //! Find a tag, value pair.
   vtkDICOMDataElement *FindDataElement(vtkDICOMTag tag);

--- a/Source/vtkDICOMParser.h
+++ b/Source/vtkDICOMParser.h
@@ -165,7 +165,7 @@ public:
 
 protected:
   vtkDICOMParser();
-  ~vtkDICOMParser();
+  ~vtkDICOMParser() VTK_DICOM_OVERRIDE;
 
   //! Internal method for filling the buffer.
   /*!

--- a/Source/vtkDICOMReader.h
+++ b/Source/vtkDICOMReader.h
@@ -315,7 +315,7 @@ public:
 
 protected:
   vtkDICOMReader();
-  ~vtkDICOMReader();
+  ~vtkDICOMReader() VTK_DICOM_OVERRIDE;
 
   //@{
   //! Entry point for all pipeline requests.

--- a/Source/vtkDICOMSCGenerator.h
+++ b/Source/vtkDICOMSCGenerator.h
@@ -49,7 +49,7 @@ public:
 
 protected:
   vtkDICOMSCGenerator();
-  ~vtkDICOMSCGenerator();
+  ~vtkDICOMSCGenerator() VTK_DICOM_OVERRIDE;
 
   //! Generate the SC Equipment Module.
   virtual bool GenerateSCEquipmentModule(vtkDICOMMetaData *source);

--- a/Source/vtkDICOMSliceSorter.h
+++ b/Source/vtkDICOMSliceSorter.h
@@ -181,7 +181,7 @@ public:
 
 protected:
   vtkDICOMSliceSorter();
-  ~vtkDICOMSliceSorter();
+  ~vtkDICOMSliceSorter() VTK_DICOM_OVERRIDE;
 
   // Sort the input files, put the sort in the supplied arrays.
   virtual void SortFiles(vtkIntArray *fileArray, vtkIntArray *frameArray);

--- a/Source/vtkDICOMSorter.h
+++ b/Source/vtkDICOMSorter.h
@@ -36,7 +36,7 @@ public:
 
 protected:
   vtkDICOMSorter();
-  ~vtkDICOMSorter();
+  ~vtkDICOMSorter() VTK_DICOM_OVERRIDE;
 
 private:
 #ifdef VTK_DICOM_DELETE

--- a/Source/vtkDICOMToRAS.h
+++ b/Source/vtkDICOMToRAS.h
@@ -133,7 +133,7 @@ public:
 
 protected:
   vtkDICOMToRAS();
-  ~vtkDICOMToRAS();
+  ~vtkDICOMToRAS() VTK_DICOM_OVERRIDE;
 
   //! Check whether the data will be reordered in cols or rows.
   void CheckNeedToReorder();

--- a/Source/vtkDICOMUIDGenerator.h
+++ b/Source/vtkDICOMUIDGenerator.h
@@ -96,7 +96,7 @@ public:
 
 protected:
   vtkDICOMUIDGenerator();
-  ~vtkDICOMUIDGenerator();
+  ~vtkDICOMUIDGenerator() VTK_DICOM_OVERRIDE;
 
   char *UIDPrefix;
   char UIDPrefixStore[64];

--- a/Source/vtkDICOMUtilities.h
+++ b/Source/vtkDICOMUtilities.h
@@ -198,7 +198,7 @@ public:
 
 protected:
   vtkDICOMUtilities() {}
-  ~vtkDICOMUtilities() {}
+  ~vtkDICOMUtilities() VTK_DICOM_OVERRIDE {}
 
   static long long GetLocalOffset(long long t);
 

--- a/Source/vtkDICOMWriter.h
+++ b/Source/vtkDICOMWriter.h
@@ -230,7 +230,7 @@ public:
 
 protected:
   vtkDICOMWriter();
-  ~vtkDICOMWriter();
+  ~vtkDICOMWriter() VTK_DICOM_OVERRIDE;
 
   //! Compute the name of one of the output files.
   void ComputeInternalFileName(int slice);

--- a/Source/vtkNIFTIHeader.h
+++ b/Source/vtkNIFTIHeader.h
@@ -369,7 +369,7 @@ public:
 
 protected:
   vtkNIFTIHeader();
-  ~vtkNIFTIHeader();
+  ~vtkNIFTIHeader() VTK_DICOM_OVERRIDE;
 
   char Magic[12];
   vtkTypeInt64 VoxOffset;

--- a/Source/vtkNIFTIReader.h
+++ b/Source/vtkNIFTIReader.h
@@ -165,7 +165,7 @@ public:
 
 protected:
   vtkNIFTIReader();
-  ~vtkNIFTIReader();
+  ~vtkNIFTIReader() VTK_DICOM_OVERRIDE;
 
   //! Read the header information.
   int RequestInformation(

--- a/Source/vtkNIFTIWriter.h
+++ b/Source/vtkNIFTIWriter.h
@@ -181,7 +181,7 @@ public:
 
 protected:
   vtkNIFTIWriter();
-  ~vtkNIFTIWriter();
+  ~vtkNIFTIWriter() VTK_DICOM_OVERRIDE;
 
   //! Generate the header information for the file.
   int GenerateHeader(vtkInformation *info, bool singleFile);

--- a/Source/vtkScancoCTReader.h
+++ b/Source/vtkScancoCTReader.h
@@ -169,7 +169,7 @@ public:
 
 protected:
   vtkScancoCTReader();
-  ~vtkScancoCTReader();
+  ~vtkScancoCTReader() VTK_DICOM_OVERRIDE;
 
   //! Read the header information.
   int RequestInformation(


### PR DESCRIPTION
Fixes warnings turned up with clang option
-Winconsistent-missing-destructor-override

Turned up after adding more warning flags on VTK dashboard machine `trey`: https://open.cdash.org/viewBuildError.php?type=1&buildid=6246282