### PR TITLE
Cast input to isprint into unsigned char

### DIFF
--- a/Programs/niftidump.cxx
+++ b/Programs/niftidump.cxx
@@ -71,7 +71,7 @@ const char *stringSanitize(
   size_t i;
   for (i = 0; i < l && cp[i] != '\0'; i++)
   {
-    if (isprint(cp[i]))
+    if (isprint((unsigned char)cp[i]))
     {
       op[i] = cp[i];
     }


### PR DESCRIPTION
man page for isprint states:

The  standards  require  that  the argument c for these functions is either EOF or a value that is representable in the type unsigned char.  If the argument c is of type char, it must be cast to unsigned char.