### PR TITLE
Fix various source comment/doc typos

### DIFF
--- a/CMake/vtkWrapHierarchy.cmake
+++ b/CMake/vtkWrapHierarchy.cmake
@@ -132,7 +132,7 @@ $<$<BOOL:$<TARGET_PROPERTY:${module_name},INCLUDE_DIRECTORIES>>:
   set(OTHER_HIERARCHY_FILES)
   # Don't use ${module_name}_DEPENDS. That list also includes COMPILE_DEPENDS,
   # which aren't library dependencies, merely dependencies for generators and
-  # such. The dependecies specified under "DEPENDS" in the vtk_module(..) macro
+  # such. The dependencies specified under "DEPENDS" in the vtk_module(..) macro
   # call are located under _LINK_DEPENDS.
   if(NOT ${module_name}_WRAP_DEPENDS)
     set(${module_name}_WRAP_DEPENDS ${${module_name}_LINK_DEPENDS})

--- a/Documents/CharacterSet.md
+++ b/Documents/CharacterSet.md
@@ -38,7 +38,7 @@ The extra characters that are supported by the decoder cannot also be
 supported by the encoder, since that would create files that do not
 conform with the DICOM standard.  Instead, the encoder will convert
 the extra characters to ASCII code points in cases where there is a
-suitable replacment.
+suitable replacement.
 
 The conversions that the encoder uses are as follows:
 
@@ -137,7 +137,7 @@ Notes:
    the same method for encoding romaji and half-width katakana, but with a
    different way of encoding the JIS X 0208 characters.
 2. This specifies the most widely used subset of iso-2022-jp, using only ASCII
-   and JIS X 0208:1900.  For broad compability, this is the best.
+   and JIS X 0208:1900.  For broad compatibility, this is the best.
 3. This specifies the most widely used subset of iso-2022-jp-2, like the above
    but adding JIS X 0212:1990 for additional characters.
 
@@ -146,7 +146,7 @@ both because it requires the use of romaji (not ASCII) in G0, and
 because half-width katakana are not supported by either iso-2022-jp
 or by iso-2022-jp-2.
 
-For (2) and (3) above, when our encoder encouters half-width katakana,
+For (2) and (3) above, when our encoder encounters half-width katakana,
 it will convert them to full-width katakana for ISO 2022 IR 87. For (1),
 or whenever ISO IR 13 is present, the half-width katakana will be
 encoded as-is.

--- a/Documents/ImageReader.md
+++ b/Documents/ImageReader.md
@@ -145,7 +145,7 @@ RescaleIntercept for each slice.
 The vtkDICOMReader provides the rescaling information, along with all the
 other meta data, via the VTK data pipeline (i.e. via GetOutputPort()).
 If you use this filter together with vtkDICOMCTRectifier in the same
-pipeline, it is recommened that this filter comes before the rectifier.
+pipeline, it is recommended that this filter comes before the rectifier.
 
 ## Multi-dimensional images
 

--- a/Documents/Main.md
+++ b/Documents/Main.md
@@ -12,7 +12,7 @@ for interrogating and converting DICOM files.
 
 Note that if you download the zip file from github, all of the
 files will have unix-style line endings.  Windows users should
-therefore clone the respository with git, instead of downloading
+therefore clone the repository with git, instead of downloading
 the zip file, otherwise they might have difficulty viewing and
 compiling the source code.
 

--- a/Programs/dicompull.cxx
+++ b/Programs/dicompull.cxx
@@ -85,7 +85,7 @@ void dicompull_help(FILE *file, const char *cp)
     "The output directory given with \"-o\" can use DICOM attributes, by\n"
     "naming those attributes within curly braces.  For example, consider\n"
     "\"{PatientID}/{StudyDescription}/{SeriesDescription}-{SeriesNumber}\"\n"
-    "or something similar to produce a hierarchichal directory structure.\n"
+    "or something similar to produce a hierarchical directory structure.\n"
     "\n"
     "The files to be copied are specified with search keys, which take the\n"
     "form \"-k key=value\" where keys can either use the standard names given\n"

--- a/Programs/dicomtocsv.cxx
+++ b/Programs/dicomtocsv.cxx
@@ -1045,7 +1045,7 @@ int MAINMACRO(int argc, char *argv[])
   {
     vtkSmartPointer<ProgressObserver> p;
 
-    // Set the default characte set
+    // Set the default character set
     vtkDICOMCharacterSet::SetGlobalDefault(charset);
 
     vtkSmartPointer<vtkDICOMDirectory> finder =

--- a/Programs/dicomtonifti.cxx
+++ b/Programs/dicomtonifti.cxx
@@ -195,7 +195,7 @@ void dicomtonifti_help(FILE *file, const char *command_name)
     "constructed from DICOM attributes, by providing the attribute names\n"
     "within curly braces.  For example, consider the following:\n"
     "\"{PatientID}-{StudyDate}/{SeriesDescription}-{SeriesNumber}.nii\"\n"
-    "or something similar to produce a hierarchichal directory structure.\n"
+    "or something similar to produce a hierarchical directory structure.\n"
     "The attributes used in the path should be from the following list:\n"
     "  PatientID, PatientName, PatientBirthDate, PatientSex,\n"
     "  StudyID, StudyDescription, StudyDate, StudyTime, StudyInstanceUID,\n"

--- a/Readme.txt
+++ b/Readme.txt
@@ -11,7 +11,7 @@ for interrogating and converting DICOM files.
 
 Note that if you download the zip file from github, all of the
 files will have unix-style line endings.  Windows users should
-therefore clone the respository with git, instead of downloading
+therefore clone the repository with git, instead of downloading
 the zip file, otherwise they might have difficulty viewing and
 compiling the source code.
 

--- a/Source/vtkDICOMDirectory.cxx
+++ b/Source/vtkDICOMDirectory.cxx
@@ -1557,7 +1557,7 @@ void vtkDICOMDirectory::SortFiles(vtkStringArray *input)
       size_t l = v.PatientName.GetVL();
       if (!cp)
       {
-        // if PatientName key is missing, use PatientID as replacment
+        // if PatientName key is missing, use PatientID as replacement
         cp = v.PatientID.GetCharData();
         l = v.PatientID.GetVL();
       }
@@ -2031,7 +2031,7 @@ void vtkDICOMDirectory::ProcessOsirixDatabase(const char *fname)
     int studyIdx = this->GetNumberOfStudies();
     int patientIdx;
     int firstUnusedPatientIdx = this->GetNumberOfPatients();
-    // Loop until corrent patientIdx is found
+    // Loop until correct patientIdx is found
     for (patientIdx = 0; patientIdx < firstUnusedPatientIdx; patientIdx++)
     {
       const vtkDICOMItem& pitem = this->GetPatientRecord(patientIdx);

--- a/Source/vtkDICOMGenerator.h
+++ b/Source/vtkDICOMGenerator.h
@@ -350,7 +350,7 @@ protected:
     const DC::EnumType *tags, vtkDICOMMetaData *source);
   //@}
 
-  //! Copy all atributes into the meta data, excluding blacklisted ones.
+  //! Copy all attributes into the meta data, excluding blacklisted ones.
   /*!
    *  The blacklist must be terminated with DC::ItemDelimitationItem.
    *  The blacklist may be set to NULL.

--- a/Source/vtkDICOMSliceSorter.h
+++ b/Source/vtkDICOMSliceSorter.h
@@ -150,7 +150,7 @@ public:
    *  This is only used for enhanced multi-frame images.  If used, then
    *  SetTimeTag() must also be used to specify which tag in the sequence
    *  to use for temporal sorting.  By default, the following sequence/tag
-   *  conbinations are automatically detected and applied:
+   *  combinations are automatically detected and applied:
    *  - CardiacSynchronizationSequence/NominalCardiacTriggerDelayTime
    *  - TemporalPositionSequence/TemporalPositionTimeOffset
    *  - FrameContentSequence/TemporalPositionIndex

--- a/Source/vtkDICOMToRAS.h
+++ b/Source/vtkDICOMToRAS.h
@@ -85,7 +85,7 @@ public:
   //@}
 
   //@{
-  //! Set whether the RAS matrix should hava a non-zero final column.
+  //! Set whether the RAS matrix should have a non-zero final column.
   /*!
    *  By default, the RAS matrix produced by this filter will have a
    *  position coordinate in its final column (NIfTI style).

--- a/Source/vtkDICOMUIDGenerator.cxx
+++ b/Source/vtkDICOMUIDGenerator.cxx
@@ -108,7 +108,7 @@ void vtkDICOMUIDGenerator::SetUIDPrefix(const char *uid)
 //----------------------------------------------------------------------------
 namespace {
 
-// divide a hexdecimal string by 10 and return the remainder,
+// divide a hexadecimal string by 10 and return the remainder,
 // this is a helper function for converting a long hex string
 // (a uuid) into a decimal string (for a uid)
 int vtkDivideHexStringBy10(char *value)

--- a/Source/vtkDICOMValue.h
+++ b/Source/vtkDICOMValue.h
@@ -123,7 +123,7 @@ public:
   //@}
 
   //@{
-  //! Create an emtpy value.
+  //! Create an empty value.
   explicit vtkDICOMValue(vtkDICOMVR vr);
 
   //! Copy constructor.
@@ -153,7 +153,7 @@ public:
   /*!
    *  This will convert a UTF-8 string to the target encoding and store
    *  the result in a new value.  If the target encoding is ISO 2022,
-   *  then escape codes will be added before and after delimeters as
+   *  then escape codes will be added before and after delimiters as
    *  necessary (the delimiters are 'backslash' for multi-valued VRs,
    *  and '^', '=' for PN).
    */
@@ -202,7 +202,7 @@ public:
    *  - for UN, the number of bytes will be returned.
    *  - for attribute tags (VR is AT) the number of tags will be returned.
    *  - for sequences (SQ) the number of items in the sequence,
-   *    excluding any delimeters, will be returned.
+   *    excluding any delimiters, will be returned.
    */
   size_t GetNumberOfValues() const {
     return (this->V ? this->V->NumberOfValues

--- a/Source/vtkNIFTIReader.cxx
+++ b/Source/vtkNIFTIReader.cxx
@@ -784,7 +784,7 @@ int vtkNIFTIReader::RequestInformation(
   //    offset when R is the identity matrix.
   //
   // 3) If there is a qform and qfac is -1, then the situation is more
-  //    compilcated.  We have three choices, each of which is a compromise:
+  //    complicated.  We have three choices, each of which is a compromise:
   //    a) we can use Spacing[2] = qfac*pixdim[3], i.e. use a negative
   //       slice spacing, which might cause some VTK algorithms to
   //       misbehave (the VTK tests only use images with positive spacing).

--- a/Utilities/charnotes.txt
+++ b/Utilities/charnotes.txt
@@ -97,7 +97,7 @@ with the following defined term:
 The choice to require ISO 2022 escape codes with Korean in DICOM is strange,
 since typical use of KS X 1001 outside of DICOM does not use escape codes.
 When KS X 1001 double-byte characters are used, the high bit of both bytes
-is set, which allows them to be distinguised from ASCII even when no
+is set, which allows them to be distinguished from ASCII even when no
 escape codes are present.  Therefore, the omission of 'ISO_IR 149' as
 a defined term for SpecificCharacterSet is odd.
 
@@ -107,7 +107,7 @@ required.  When SpecificCharacterSet is 'ISO 2022 IR 149', the best
 practise is to use an euc-kr decoder (or CP949 or IBM 970) and to
 simply filter out any escape codes that are present.
 
-Suport for the Thai TIS 620 was introduced by CP 194, 1999, with the
+Support for the Thai TIS 620 was introduced by CP 194, 1999, with the
 following defined terms:
 
     ISO_IR 166 -> TIS 620, Thai


### PR DESCRIPTION
Found via `codespell -q 3 -L ba,didi,hel,infarction,ot,ro,ther,`