### PR TITLE
gdcm::Reader expects utf-8 paths

### DIFF
--- a/Source/vtkDICOMReader.cxx
+++ b/Source/vtkDICOMReader.cxx
@@ -1846,12 +1846,6 @@ bool vtkDICOMReader::ReadFileDelegated(
 
   (void)fileIdx;
 
-#ifdef _WIN32
-  // Convert utf8 filename to local character set for gdcm
-  vtkDICOMFilePath filePath(filename);
-  filename = filePath.Local();
-#endif
-
   gdcm::ImageReader reader;
   reader.SetFileName(filename);
   if(!reader.Read())


### PR DESCRIPTION
This is tested with path in Chinese. It is also confirmed by checking the code at  gdcmReader.cxx: Reader::SetFileName(const char* utf8path)